### PR TITLE
shamil - the list of dishes and a separate dish

### DIFF
--- a/components/ListOfDishes/CardDish/CardDish.styles.ts
+++ b/components/ListOfDishes/CardDish/CardDish.styles.ts
@@ -2,13 +2,12 @@ import styled from "styled-components"
 import { IImg } from "./CardDish.interface"
 
 export const StyledBox = styled.div`
-  width: 220px;
   height: 202px;
   background: #ffffff;
   box-shadow: 0px 1.75848px 4.39621px rgba(0, 0, 0, 0.15);
   border-radius: 7.03394px;
   padding: 3px;
-  margin: 0 30px 72px 0;
+  margin: 0 0px 72px 0;
 `
 
 export const StyledContentBox = styled.div`
@@ -34,6 +33,8 @@ export const StyledImage = styled.div<IImg>`
 export const StyledTextBox = styled.div`
   padding-top: 10px;
   text-align: center;
+  max-width: 210px;
+  margin: 0 auto;
 `
 
 export const StyledName = styled.p`
@@ -45,8 +46,6 @@ export const StyledName = styled.p`
   color: #000000;
   margin-bottom: 10px;
   padding: 0;
-
-  max-width: 210px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/components/ListOfDishes/el.styles.ts
+++ b/components/ListOfDishes/el.styles.ts
@@ -1,9 +1,9 @@
 import styled from "styled-components"
 
 export const StyledMainWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    width: 100%;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 `
 
 export const StyledContainer = styled.div`
@@ -12,4 +12,8 @@ export const StyledContainer = styled.div`
   display: flex;
   width: 100%;
   margin-bottom: 15px;
+`
+
+export const StyledSliderAnchorDish = styled.a`
+  margin: 0 18px;
 `

--- a/components/ListOfDishes/listOfDishes.styles.ts
+++ b/components/ListOfDishes/listOfDishes.styles.ts
@@ -8,9 +8,9 @@ export const SideBarWrapper = styled.div`
 `
 
 export const SideBarCheckBox = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 `
 export const BoxCheckBox = styled.div`
   display: flex;
@@ -92,11 +92,16 @@ export const MenuH2 = styled.h2`
 `
 
 export const ListDishes = styled.div`
-    margin: 0 30px;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
+  margin: 0 18px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+`
+
+export const StyledAnchorDish = styled.a`
+  width: calc(100% / 3 - 24px);
+  margin: 12px;
 `
 
 export const SpecificationWrapper = styled.div`

--- a/components/ListOfDishes/listOfDishes.styles.ts
+++ b/components/ListOfDishes/listOfDishes.styles.ts
@@ -92,6 +92,7 @@ export const MenuH2 = styled.h2`
 `
 
 export const ListDishes = styled.div`
+  width: 100%;
   margin: 0 18px;
   display: flex;
   flex-direction: row;
@@ -102,6 +103,14 @@ export const ListDishes = styled.div`
 export const StyledAnchorDish = styled.a`
   width: calc(100% / 3 - 24px);
   margin: 12px;
+
+  @media (max-width: 1509px) {
+    width: calc(100% / 2 - 24px);
+  }
+
+  @media (max-width: 1259px) {
+    width: calc(100% - 24px);
+  }
 `
 
 export const SpecificationWrapper = styled.div`

--- a/pages/user/calendar/dietaplan/[food].tsx
+++ b/pages/user/calendar/dietaplan/[food].tsx
@@ -1,12 +1,14 @@
 import CalendarContainer from "@/components/Calendar/calendarContainer"
 import Dish from "@/components/Dish/dish"
+import { LayoutUser } from "@/containers/Layout-user/layoutUser"
+import WithRefreshingToken from "@/containers/Layout-user/WithRefreshingToken"
 
 const FoodDishItem = () => {
-    return (
-        <CalendarContainer>
-            <Dish />
-        </CalendarContainer>
-    )
+  return (
+    <CalendarContainer>
+      <Dish />
+    </CalendarContainer>
+  )
 }
 
-export default FoodDishItem
+export default WithRefreshingToken(LayoutUser(FoodDishItem))

--- a/pages/user/listOfDishes/dish/[el].tsx
+++ b/pages/user/listOfDishes/dish/[el].tsx
@@ -11,6 +11,7 @@ import generateId from "@/utils/generateId"
 import {
   StyledMainWrapper,
   StyledContainer,
+  StyledSliderAnchorDish,
 } from "@/components/ListOfDishes/el.styles"
 
 import * as styles from "@/components/ListOfDishes/CardDish/inline.styles"
@@ -37,9 +38,9 @@ const DishesItem = (): JSX.Element => {
       key={generateId()}
       passHref
     >
-      <a>
+      <StyledSliderAnchorDish>
         <CardDish data={item} styles={styles} />
-      </a>
+      </StyledSliderAnchorDish>
     </Link>
   ))
 

--- a/pages/user/listOfDishes/dish/[el].tsx
+++ b/pages/user/listOfDishes/dish/[el].tsx
@@ -16,13 +16,22 @@ import {
 import * as styles from "@/components/ListOfDishes/CardDish/inline.styles"
 
 import { dishFoodAll } from "@/models/dish/dish"
+import { useRouter } from "next/router"
+import { specificationStar } from "@/models/sideBar/sideBar"
 
 const DishesItem = (): JSX.Element => {
-
   // пока нет апи используем фейковые данные dishFoodAll
   // в слайдере должен находиться список отфильтрованных карточек
+  const { asPath } = useRouter()
 
-  const listDishes = dishFoodAll.map(item => (
+  const urlQuery = asPath.split("?")[1]
+
+  const filteredListDishes = dishFoodAll.filter(item => {
+    const star = specificationStar.filter(s => s.id === item.star)[0]
+    return urlQuery.includes(item.id) && urlQuery.includes(star.name)
+  })
+
+  const listDishes = filteredListDishes.map(item => (
     <Link
       href={`/user/listOfDishes/dish/${item.id}`}
       key={generateId()}

--- a/pages/user/listOfDishes/index.tsx
+++ b/pages/user/listOfDishes/index.tsx
@@ -4,7 +4,7 @@ import Pagination from "@mui/material/Pagination"
 import Stack from "@mui/material/Stack"
 import Link from "next/link"
 
-import CardDish from "@/components/ListOfDishes/CardDish/CardDish" 
+import CardDish from "@/components/ListOfDishes/CardDish/CardDish"
 
 import SideBar from "@/components/ListOfDishes/sideBar"
 import { dishFoodAll } from "@/models/dish/dish"
@@ -13,6 +13,7 @@ import {
   AllMenusWrapper,
   ListDishes,
   LayoutMenuWrapper,
+  StyledAnchorDish,
 } from "@/components/ListOfDishes/listOfDishes.styles"
 import { IFoodItemType } from "@/models/models.interface"
 import { LayoutUser } from "@/containers/Layout-user/layoutUser"
@@ -29,8 +30,6 @@ import {
 
 import { FontPoppins, FontOpenSans } from "@/utils/fonts/fontStyles"
 //import { relative } from "path"
-
-
 
 // Апи для получения блюд пока нет.
 // Все на фейковых данных "dishFoodAll".
@@ -125,13 +124,13 @@ const AllMenus = () => {
 
   const elems = dishFood.map((item: IFoodItemType, index) => {
     if (index >= minResOnPage && index < maxResOnPage) {
-        return (
-          <Link href={`/user/listOfDishes/dish/${item.id}`} passHref>
-            <a>
-              <CardDish data={item} />
-            </a>
-          </Link>
-        )
+      return (
+        <Link href={`/user/listOfDishes/dish/${item.id}`} passHref>
+          <StyledAnchorDish>
+            <CardDish data={item} />
+          </StyledAnchorDish>
+        </Link>
+      )
     }
   })
 

--- a/pages/user/listOfDishes/index.tsx
+++ b/pages/user/listOfDishes/index.tsx
@@ -145,10 +145,24 @@ const AllMenus = () => {
     setCountPages(Math.ceil(dishFood.length / dishesAmount))
   }, [dishFood])
 
+  const formStringFromCheckedCheckboxes = () => {
+    const allCheckboxes = { ...checkbox, ...checkboxMeals }
+    let string = "?"
+    for (const ch in allCheckboxes) {
+      if (allCheckboxes[ch]) {
+        string += `${ch}=true&`
+      }
+    }
+    return string.substring(0, string.length - 1)
+  }
+
   const elems = dishFood.map((item: IFoodItemType, index) => {
     if (index >= minResOnPage && index < maxResOnPage) {
       return (
         <Link
+          as={`/user/listOfDishes/dish/${
+            item.id
+          }${formStringFromCheckedCheckboxes()}`}
           href={`/user/listOfDishes/dish/${item.id}`}
           passHref
           key={generateId()}

--- a/pages/user/listOfDishes/index.tsx
+++ b/pages/user/listOfDishes/index.tsx
@@ -156,24 +156,26 @@ const AllMenus = () => {
     return string.substring(0, string.length - 1)
   }
 
-  const elems = dishFood.map((item: IFoodItemType, index) => {
-    if (index >= minResOnPage && index < maxResOnPage) {
-      return (
+  const elems = []
+
+  for (let i = minResOnPage; i < maxResOnPage; i++) {
+    if (dishFood[i]) {
+      elems.push(
         <Link
           as={`/user/listOfDishes/dish/${
-            item.id
+            dishFood[i].id
           }${formStringFromCheckedCheckboxes()}`}
-          href={`/user/listOfDishes/dish/${item.id}`}
+          href={`/user/listOfDishes/dish/${dishFood[i].id}`}
           passHref
           key={generateId()}
         >
           <StyledAnchorDish>
-            <CardDish data={item} />
+            <CardDish data={dishFood[i]} />
           </StyledAnchorDish>
         </Link>
       )
     }
-  })
+  }
 
   return (
     <AllMenusWrapper>

--- a/pages/user/listOfDishes/index.tsx
+++ b/pages/user/listOfDishes/index.tsx
@@ -29,12 +29,15 @@ import {
 } from "@/models/sideBar/sideBar"
 
 import { FontPoppins, FontOpenSans } from "@/utils/fonts/fontStyles"
+import { getDishesPerPage } from "@/utils/getDishesPerPage"
+import generateId from "@/utils/generateId"
 //import { relative } from "path"
 
 // Апи для получения блюд пока нет.
 // Все на фейковых данных "dishFoodAll".
 
 const AllMenus = () => {
+  let [dishesAmount, setDishesAmount] = useState(getDishesPerPage)
   const [checkbox, setCheckbox] = useState<ISideBarCheckBoxStar>(
     initialValuesCheckBoxStar
   )
@@ -98,17 +101,37 @@ const AllMenus = () => {
     setDishFood(foodFilter)
   }, [checkbox, checkboxMeals])
 
-  const [countPages, setCountPages] = useState(Math.ceil(dishFood.length / 6))
+  const [countPages, setCountPages] = useState(
+    Math.ceil(dishFood.length / dishesAmount)
+  )
   const [currentPage, setCurrentPage] = useState(1)
   const [minResOnPage, setMinResOnPage] = useState(0)
-  const [maxResOnPage, setMaxResOnPage] = useState(6)
+  const [maxResOnPage, setMaxResOnPage] = useState(dishesAmount)
+
+  useEffect(() => {
+    function handleWindowResize() {
+      setDishesAmount(getDishesPerPage())
+    }
+
+    window.addEventListener("resize", handleWindowResize)
+
+    return () => {
+      window.removeEventListener("resize", handleWindowResize)
+    }
+  }, [])
+
+  useEffect(() => {
+    setCountPages(Math.ceil(dishFood.length / dishesAmount))
+    setMinResOnPage(() => (currentPage - 1) * dishesAmount)
+    setMaxResOnPage(() => currentPage * dishesAmount)
+  }, [dishesAmount])
 
   const changePage = page => {
     if (!page) {
       return
     }
-    setMinResOnPage(() => (page - 1) * 6)
-    setMaxResOnPage(() => page * 6)
+    setMinResOnPage(() => (page - 1) * dishesAmount)
+    setMaxResOnPage(() => page * dishesAmount)
     setCurrentPage(page)
   }
 
@@ -119,13 +142,17 @@ const AllMenus = () => {
   }, [countPages, currentPage])
 
   useEffect(() => {
-    setCountPages(Math.ceil(dishFood.length / 6))
+    setCountPages(Math.ceil(dishFood.length / dishesAmount))
   }, [dishFood])
 
   const elems = dishFood.map((item: IFoodItemType, index) => {
     if (index >= minResOnPage && index < maxResOnPage) {
       return (
-        <Link href={`/user/listOfDishes/dish/${item.id}`} passHref>
+        <Link
+          href={`/user/listOfDishes/dish/${item.id}`}
+          passHref
+          key={generateId()}
+        >
           <StyledAnchorDish>
             <CardDish data={item} />
           </StyledAnchorDish>

--- a/utils/getDishesPerPage.ts
+++ b/utils/getDishesPerPage.ts
@@ -1,7 +1,7 @@
 export function getDishesPerPage() {
   if (typeof window !== "undefined") {
     const { innerWidth } = window
-    let dishes = innerWidth < 1260 ? 1 : innerWidth < 1510 ? 4 : 6
+    let dishes = innerWidth < 1260 ? 2 : innerWidth < 1510 ? 4 : 6
     return dishes
   }
 }

--- a/utils/getDishesPerPage.ts
+++ b/utils/getDishesPerPage.ts
@@ -1,0 +1,7 @@
+export function getDishesPerPage() {
+  if (typeof window !== "undefined") {
+    const { innerWidth } = window
+    let dishes = innerWidth < 1260 ? 1 : innerWidth < 1510 ? 4 : 6
+    return dishes
+  }
+}


### PR DESCRIPTION
1. Поправил разметку и стили, чтобы, согласно макету, в списке блюд отображалось по три блюда в ряду
2. Добавил отзывчивость списка блюд в зависимости от ширины экрана: по три в ряд, по два в ряд, по одному в ряд
3. В слайдере на странице отдельного блюда теперь отображаются только те блюда, которые были выбраны в фильтре на странице со списком блюд
4. Добавил LayoutUser для отображения отдельного блюда при переходе на эту страницу с календаря
5. Заменил цикл map на for, чтобы предотвратить перебор всего списка блюд при пагинации: не нужно проходить по тем блюдам, которые отображаются, например, на первой странице